### PR TITLE
Hide test title

### DIFF
--- a/templates/default/seb_test_running.css
+++ b/templates/default/seb_test_running.css
@@ -5,3 +5,11 @@
 .il-logo {
 	margin-right: 1.5rem;
 }
+
+#headerimage, h1.ilHeader {
+	display: none;
+}
+
+div.il_HeaderInner {
+	padding-top: 0px;
+}


### PR DESCRIPTION
Hide the test title to save vertical space, as it is already displayed in the header bar.